### PR TITLE
Update the runtime version to 25.08.

### DIFF
--- a/de.danielnoethen.butt.json
+++ b/de.danielnoethen.butt.json
@@ -1,7 +1,7 @@
 {
     "app-id": "de.danielnoethen.butt",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "24.08",
+    "runtime-version": "25.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "butt",
     "rename-icon": "butt",
@@ -27,17 +27,23 @@
     "modules": [
         {
             "name": "portaudio",
-            "buildsystem": "cmake-ninja",
+            "buildsystem": "autotools",
             "config-opts": [
-                "-DCMAKE_BUILD_TYPE=RelWithDebInfo"
+                "--enable-cxx"
             ],
+            "no-parallel-make": true,
             "sources": [
                 {
-                    "type": "archive",
-                    "url": "https://github.com/PortAudio/portaudio/archive/refs/tags/v19.7.0.tar.gz",
-                    "sha256": "5af29ba58bbdbb7bbcefaaecc77ec8fc413f0db6f4c4e286c40c3e1b83174fa0"
+                    "type": "git",
+                    "url": "https://github.com/PortAudio/portaudio.git",
+                    "tag": "v19.7.0",
+                    "commit": "147dd722548358763a8b649b3e4b41dfffbcfbb6"
                 }
-            ]
+            ],
+            "x-checker-data": {
+                "type": "git",
+                "tag-pattern": "^v([\\d.]+)$"
+            }
         },
         {
             "name": "portmidi",
@@ -47,14 +53,19 @@
             ],
             "sources": [
                 {
-                    "type": "archive",
-                    "url": "https://github.com/PortMidi/portmidi/archive/refs/tags/v2.0.4.tar.gz",
-                    "sha256": "64893e823ae146cabd3ad7f9a9a9c5332746abe7847c557b99b2577afa8a607c"
+                    "type": "git",
+                    "url": "https://github.com/PortMidi/portmidi.git",
+                    "tag": "v2.0.8",
+                    "commit": "101dac9455e2718512c94e24cbcae6a6f34b908b"
                 }
             ],
             "cleanup": [
                 "/bin"
-            ]
+            ],
+            "x-checker-data": {
+                "type": "git",
+                "tag-pattern": "^v([\\d.]+)$"
+            }
         },
         {
             "name": "libdatachannel",
@@ -65,26 +76,55 @@
                 "-DNO_EXAMPLES=1",
                 "-DCMAKE_BUILD_TYPE=Release"
             ],
+            "builddir": true,
             "sources": [
                 {
                     "type": "git",
                     "url": "https://github.com/paullouisageneau/libdatachannel.git",
-                    "tag": "v0.22.4",
-                    "commit": "20bf658a60881854984f8ffb1586a4722bf590ec"
+                    "tag": "v0.24.2",
+                    "commit": "4e4f4892dccb2a57fe3a490d0c9d958de4244e74"
                 }
-            ]
+            ],
+            "x-checker-data": {
+                "type": "git",
+                "tag-pattern": "^v([\\d.]+)$"
+            }
+        },
+        {
+            "name": "libfdk-aac",
+            "buildsystem": "autotools",
+            "config-opts": [
+                "--disable-static"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/mstorsjo/fdk-aac.git",
+                    "tag": "v2.0.3",
+                    "commit": "716f4394641d53f0d79c9ddac3fa93b03a49f278"
+                }
+            ],
+            "x-checker-data": {
+                "type": "git",
+                "tag-pattern": "^v([\\d.]+)$"
+            }
         },
         {
             "name": "fltk",
             "buildsystem": "cmake-ninja",
+            "builddir": true,
             "sources": [
                 {
                     "type": "git",
                     "url": "https://github.com/fltk/fltk.git",
-                    "tag": "release-1.3.9",
-                    "commit": "a66273e72621887fcbd0ee5dca2dd133356d5d8a"
+                    "tag": "release-1.3.11",
+                    "commit": "702172a951a2bb4f25afe31008ef3fcbb5bfb92f"
                 }
-            ]
+            ],
+            "x-checker-data": {
+                "type": "git",
+                "tag-pattern": "^release-1.3.([\\d.]+)$"
+            }
         },
         {
             "name": "butt",


### PR DESCRIPTION
Changes:
- 25.08 nolonger includes fdk-aac so this has been included to add acc support.
- Portaudio has been switched to autotools to avoid the CMake incompatibility.
- x-checker-data has been added to the portaudio module to allow for automatic updates.